### PR TITLE
Set update type

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,4 +1,0 @@
-{
-    "python.linting.flake8Enabled": true,
-    "python.linting.enabled": true
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,4 @@
+{
+    "python.linting.flake8Enabled": true,
+    "python.linting.enabled": true
+}

--- a/datastore_version_manager/adapter/built_datasets.py
+++ b/datastore_version_manager/adapter/built_datasets.py
@@ -1,6 +1,7 @@
 import os
 from typing import Tuple
 
+
 def get_metadata_path(dataset_name: str) -> str:
     built_dataset_dir = os.environ['BUILT_DATASETS_DIR']
     metadata_path = (

--- a/datastore_version_manager/commands.py
+++ b/datastore_version_manager/commands.py
@@ -27,7 +27,9 @@ def add_new_dataset(dataset_name: str, description: str, overwrite: bool):
             f'release status: {release_status}'
         )
 
-    built_data_path, is_partitioned = built_datasets.get_data_path(dataset_name)
+    built_data_path, is_partitioned = (
+        built_datasets.get_data_path(dataset_name)
+    )
     draft_data_path = datastore.create_data_file_path(
         dataset_name, "0.0.0", is_partitioned
     )

--- a/datastore_version_manager/domain/pending_operations.py
+++ b/datastore_version_manager/domain/pending_operations.py
@@ -74,6 +74,9 @@ def set_release_status(dataset_name: str, release_status: str, operation: str,
         pending_operations["version"] = semver.bump_draft_version(
             pending_operations["version"]
         )
+        pending_operations["updateType"] = __get_update_type(
+            pending_operations["dataStructureUpdates"]
+        )
         datastore.write_pending_operations(pending_operations)
     else:
         if datastore.is_dataset_in_data_store(dataset_name, 'RELEASED'):
@@ -128,7 +131,11 @@ def __get_update_type(data_structure_updates: list) -> str:
     operations = [
         data_structure["operation"]
         for data_structure in data_structure_updates
+        if data_structure["releaseStatus"] != "DRAFT"
     ]
+    if not operations:
+        return ""
+
     if "CHANGE_DATA" in operations or "REMOVE" in operations:
         return "MAJOR"
     elif "ADD" in operations:

--- a/datastore_version_manager/domain/pending_operations.py
+++ b/datastore_version_manager/domain/pending_operations.py
@@ -131,7 +131,9 @@ def __get_update_type(data_structure_updates: list) -> str:
     operations = [
         data_structure["operation"]
         for data_structure in data_structure_updates
-        if data_structure["releaseStatus"] != "DRAFT"
+        if data_structure["releaseStatus"] in [
+            "PENDING_RELEASE", "PENDING_DELETE"
+        ]
     ]
     if not operations:
         return ""

--- a/datastore_version_manager/domain/pending_operations.py
+++ b/datastore_version_manager/domain/pending_operations.py
@@ -136,7 +136,7 @@ def __get_update_type(data_structure_updates: list) -> str:
     elif "PATCH_METADATA":
         return "PATCH"
     else:
-        raise RuntimeError(
+        raise InvalidOperation(
             f"Invalid operation in {operations}"
         )
 

--- a/datastore_version_manager/domain/pending_operations.py
+++ b/datastore_version_manager/domain/pending_operations.py
@@ -20,7 +20,7 @@ def add_new(dataset_name: str, operation: str, release_status: str,
     pending_operations["version"] = semver.bump_draft_version(
         pending_operations["version"]
     )
-    pending_operations["updateType"] = semver.get_update_type(
+    pending_operations["updateType"] = __get_update_type(
         data_structure_updates
     )
     __archive()
@@ -41,7 +41,7 @@ def remove(dataset_name: str):
         if datastructure_updates[i]['name'] == dataset_name:
             del datastructure_updates[i]
             break
-    pending_operations["updateType"] = semver.get_update_type(
+    pending_operations["updateType"] = __get_update_type(
         pending_operations["dataStructureUpdates"]
     )
     pending_operations["releaseTime"] = date.seconds_since_epoch()
@@ -124,7 +124,28 @@ def __archive() -> None:
     datastore.write_to_archive(pending_operations, file_path)
 
 
+def __get_update_type(data_structure_updates: list) -> str:
+    operations = [
+        data_structure["operation"]
+        for data_structure in data_structure_updates
+    ]
+    if "CHANGE_DATA" in operations or "REMOVE" in operations:
+        return "MAJOR"
+    elif "ADD" in operations:
+        return "MINOR"
+    elif "PATCH_METADATA":
+        return "PATCH"
+    else:
+        raise RuntimeError(
+            f"Invalid operation in {operations}"
+        )
+
+
 class ReleaseStatusTransitionNotAllowed(Exception):
+    pass
+
+
+class InvalidOperation(Exception):
     pass
 
 

--- a/datastore_version_manager/domain/pending_operations.py
+++ b/datastore_version_manager/domain/pending_operations.py
@@ -6,8 +6,8 @@ from datastore_version_manager.util import semver, date
 def add_new(dataset_name: str, operation: str, release_status: str,
             description: str) -> None:
     pending_operations = datastore.get_pending_operations()
-    pending_operations_list = pending_operations["dataStructureUpdates"]
-    pending_operations_list.append({
+    data_structure_updates = pending_operations["dataStructureUpdates"]
+    data_structure_updates.append({
         "name": dataset_name,
         "operation": operation,
         "description": description,
@@ -18,7 +18,9 @@ def add_new(dataset_name: str, operation: str, release_status: str,
     pending_operations["version"] = semver.bump_draft_version(
         pending_operations["version"]
     )
-    
+    pending_operations["updateType"] = semver.get_update_type(
+        data_structure_updates
+    )
     datastore.write_pending_operations(pending_operations)
 
 
@@ -33,7 +35,9 @@ def remove(dataset_name: str):
         if datastructure_updates[i]['name'] == dataset_name:
             del datastructure_updates[i]
             break
-
+    pending_operations["updateType"] = semver.get_update_type(
+        pending_operations["dataStructureUpdates"]
+    )
     pending_operations["releaseTime"] = date.seconds_since_epoch()
     datastore.write_pending_operations(pending_operations)
 

--- a/datastore_version_manager/util/semver.py
+++ b/datastore_version_manager/util/semver.py
@@ -20,22 +20,5 @@ def bump_version(semver: str, index: int) -> str:
     return '.'.join(semver_list)
 
 
-def get_update_type(data_structure_updates: list) -> str:
-    operations = [
-        data_structure["operation"]
-        for data_structure in data_structure_updates
-    ]
-    if "CHANGE_DATA" in operations or "REMOVE" in operations:
-        return "MAJOR"
-    elif "ADD" in operations:
-        return "MINOR"
-    elif "PATCH_METADATA":
-        return "PATCH"
-    else:
-        raise RuntimeError(
-            f"Invalid operation in {operations}"
-        )
-
-
 def dotted_to_underscored(semver: str) -> str:
     return semver.replace('.', '_')

--- a/datastore_version_manager/util/semver.py
+++ b/datastore_version_manager/util/semver.py
@@ -18,3 +18,20 @@ def bump_version(semver: str, index: int) -> str:
     semver_list = semver.split('.')
     semver_list[index] = str(int(semver_list[index]) + 1)
     return '.'.join(semver_list)
+
+
+def get_update_type(data_structure_updates: list) -> str:
+    operations = [
+        data_structure["operation"]
+        for data_structure in data_structure_updates
+    ]
+    if "CHANGE_DATA" in operations or "REMOVE" in operations:
+        return "MAJOR"
+    elif "ADD" in operations:
+        return "MINOR"
+    elif "PATCH_METADATA":
+        return "PATCH"
+    else:
+        raise RuntimeError(
+            f"Invalid operation in {operations}"
+        )

--- a/tests/resources/SSB_FDB/datastore/pending_operations.json
+++ b/tests/resources/SSB_FDB/datastore/pending_operations.json
@@ -17,5 +17,5 @@
             "releaseStatus": "DRAFT"
         }
     ],
-    "updateType": "MINOR"
+    "updateType": ""
 }

--- a/tests/unit/domain/test_pending_operations.py
+++ b/tests/unit/domain/test_pending_operations.py
@@ -29,6 +29,8 @@ def test_remove_dataset_from_pending_operations():
     dataset_name = 'ANOTHER_TEST_DATASET'
     pending_operations.remove(dataset_name)
     data_structure_updates = datastore.get_pending_operations()["dataStructureUpdates"]
+    update_type = datastore.get_pending_operations()["updateType"]
+    assert update_type == "MINOR"
     assert len(data_structure_updates) == 1
     if datastore.draft_dataset_exists(dataset_name):
         assert False

--- a/tests/unit/domain/test_pending_operations.py
+++ b/tests/unit/domain/test_pending_operations.py
@@ -38,7 +38,7 @@ def test_remove_dataset_from_pending_operations():
 
     actual_pending_operations = datastore.get_pending_operations()
 
-    assert actual_pending_operations["updateType"] == "MINOR"
+    assert actual_pending_operations["updateType"] == ''
     assert os.path.exists(f'{ARCHIVE_DIR}/pending_operation__0_0_0_1.json')
     assert len(actual_pending_operations["dataStructureUpdates"]) == 1
     if datastore.draft_dataset_exists(dataset_name):

--- a/tests/unit/test_commands.py
+++ b/tests/unit/test_commands.py
@@ -43,6 +43,7 @@ def test_update_release_status():
     with open(PENDING_OPERATIONS_FILE_PATH) as f:
         pending_operations = json.load(f)
     assert pending_operations["version"] == "0.0.0.2"
+    assert pending_operations["updateType"] == "MINOR"
     assert {
                "name": "TEST_DATASET",
                "operation": "ADD",
@@ -63,6 +64,7 @@ def test_update_release_status_pending_delete():
     with open(PENDING_OPERATIONS_FILE_PATH) as f:
         pending_operations = json.load(f)
     assert pending_operations["version"] == "0.0.0.2"
+    assert pending_operations["updateType"] == "MAJOR"
     assert {
                "name": "PERSON_SIVILSTAND",
                "operation": "REMOVE",
@@ -76,6 +78,7 @@ def test_add_new_dataset():
     with open(PENDING_OPERATIONS_FILE_PATH) as f:
         pending_operations = json.load(f)
     assert pending_operations["version"] == "0.0.0.2"
+    assert pending_operations["updateType"] == ""
     assert {
                "name": "NEW_VARIABLE",
                "operation": "ADD",


### PR DESCRIPTION
# SET UPDATE TYPE

When updates are made to pending_operations it should update the "updateType" field.

### Why?
The pending_operations.json file has an "updateType" field. If the only pending operations are of operation type "PATCH_METADATA", this would constitute a "PATCH" update in the next datastore bump.

Similarly, if there are any "ADD" operations, the datastore version would be "MINOR" on bump. If there are any operations of type "REMOVE" or "CHANGE_DATASET", the datastore vump would be a "MAJOR" bump.

The above results in this logic:
```py
    if "CHANGE_DATA" in operations or "REMOVE" in operations:
        return "MAJOR"
    elif "ADD" in operations:
        return "MINOR"
    elif "PATCH_METADATA":
        return "PATCH"
```

## How?
* Added __get_update_type function, that parses datastructure updates to decide the updateType
* small style fixes and typo fixes
* updated assertions in tests
 