### PR TITLE
Generate metadata all draft

### DIFF
--- a/datastore_version_manager/adapter/datastore.py
+++ b/datastore_version_manager/adapter/datastore.py
@@ -17,7 +17,7 @@ def write_pending_operations(pending_operation: dict):
         f'{os.environ["DATASTORE_ROOT_DIR"]}/datastore/pending_operations.json'
     )
     with open(pending_operations_json, 'w', encoding="utf-8") as f:
-        json.dump(pending_operation, f, indent=4)
+        json.dump(pending_operation, f, indent=4, ensure_ascii=False)
 
 
 def get_datastore_info() -> dict:
@@ -33,7 +33,7 @@ def write_datastore_info(datastore_dict: dict):
         f'{os.environ["DATASTORE_ROOT_DIR"]}/datastore/data_store.json'
     )
     with open(data_store_json, 'w', encoding="utf-8") as f:
-        return json.dump(datastore_dict, f, indent=4)
+        return json.dump(datastore_dict, f, indent=4, ensure_ascii=False)
 
 
 def write_to_archive(json_dict: dict, file_path: str):
@@ -41,7 +41,7 @@ def write_to_archive(json_dict: dict, file_path: str):
         f'{os.environ["DATASTORE_ROOT_DIR"]}/archive/{file_path}'
     )
     with open(file_path, 'w', encoding="utf-8") as f:
-        json.dump(json_dict, f, indent=4)
+        json.dump(json_dict, f, indent=4, ensure_ascii=False)
 
 
 def dataset_exists(dataset_name: str):
@@ -114,8 +114,26 @@ def create_data_file_path(dataset_name: str, version: str,
 def create_metadata_file_path(dataset_name: str, version: str) -> str:
     return (
         f'{get_metadata_dir_path(dataset_name)}/'
-        f'{dataset_name}__{semver.dotted_to_underscored(version)}'
+        f'{dataset_name}__{semver.dotted_to_underscored(version)}.json'
     )
+
+
+def get_metadata_all(version: str) -> str:
+    metadata_all_file_path = (
+        f'{os.environ["DATASTORE_ROOT_DIR"]}/datastore/'
+        f'metadata_all__{semver.dotted_to_underscored(version)}.json'
+    )
+    with open(metadata_all_file_path, 'r') as f:
+        return json.load(f)
+
+
+def write_metadata_all_draft(metadata_all: dict) -> None:
+    metadata_all_draft_file_path = (
+        f'{os.environ["DATASTORE_ROOT_DIR"]}/datastore/'
+        'metadata_all__draft.json'
+    )
+    with open(metadata_all_draft_file_path, 'w') as f:
+        json.dump(metadata_all, f, indent=4, ensure_ascii=False)
 
 
 def is_dataset_in_data_store(dataset_name: str, release_status) -> bool:
@@ -128,6 +146,11 @@ def is_dataset_in_data_store(dataset_name: str, release_status) -> bool:
             ):
                 return True
     return False
+
+
+def get_latest_version():
+    datastore_info = get_datastore_info()
+    return datastore_info["versions"][0]
 
 
 class DatasetNotFound(Exception):

--- a/datastore_version_manager/adapter/datastore.py
+++ b/datastore_version_manager/adapter/datastore.py
@@ -150,7 +150,7 @@ def is_dataset_in_data_store(dataset_name: str, release_status) -> bool:
 
 def get_latest_version():
     datastore_info = get_datastore_info()
-    return datastore_info["versions"][0]
+    return datastore_info["versions"][0]["version"]
 
 
 class DatasetNotFound(Exception):

--- a/datastore_version_manager/domain/metadata_all.py
+++ b/datastore_version_manager/domain/metadata_all.py
@@ -17,7 +17,18 @@ def generate_metadata_all_draft():
                 data_structure for data_structure in data_structures
                 if data_structure['name'] != dataset_name
             ]
+        elif data_structure_update['operation'] == 'ADD':
+            draft_metadata_file_path = datastore.create_metadata_file_path(
+                dataset_name, "0.0.0"
+            )
+            with open(draft_metadata_file_path, 'r') as f:
+                draft_metadata = json.load(f)
+            data_structures.append(draft_metadata)
         else:
+            data_structures = [
+                data_structure for data_structure in data_structures
+                if data_structure['name'] != dataset_name
+            ]
             draft_metadata_file_path = datastore.create_metadata_file_path(
                 dataset_name, "0.0.0"
             )

--- a/datastore_version_manager/domain/metadata_all.py
+++ b/datastore_version_manager/domain/metadata_all.py
@@ -1,0 +1,34 @@
+import json
+
+from datastore_version_manager.adapter import datastore
+from datastore_version_manager.domain import pending_operations
+
+
+def generate_metadata_all_draft():
+    data_structure_updates = pending_operations.get_datastructure_updates()
+    latest_version = datastore.get_latest_version()
+    latest_metadata_all = datastore.get_metadata_all(latest_version[:5])
+    data_structures = latest_metadata_all['dataStructures']
+
+    for data_structure_update in data_structure_updates:
+        dataset_name = data_structure_update['name']
+        if data_structure_update['releaseStatus'] == 'PENDING_DELETE':
+            data_structures = [
+                data_structure for data_structure in data_structures
+                if data_structure['name'] != dataset_name
+            ]
+        else:
+            draft_metadata_file_path = datastore.create_metadata_file_path(
+                dataset_name, "0.0.0"
+            )
+            with open(draft_metadata_file_path, 'r') as f:
+                draft_metadata = json.load(f)
+            data_structures.append(draft_metadata)
+    datastore.write_metadata_all_draft({
+        "dataStore": latest_metadata_all["dataStore"],
+        "dataStructures": data_structures
+    })
+
+
+def generate_versioned_metadata_all():
+    pass

--- a/datastore_version_manager/domain/pending_operations.py
+++ b/datastore_version_manager/domain/pending_operations.py
@@ -1,4 +1,5 @@
 from datastore_version_manager.adapter import datastore
+from datastore_version_manager.domain import metadata_all
 from datastore_version_manager.util import semver, date
 from datastore_version_manager.adapter.constants import (
     RELEASE_STATUS_ALLOWED_TRANSITIONS
@@ -25,6 +26,7 @@ def add_new(dataset_name: str, operation: str, release_status: str,
     )
     __archive()
     datastore.write_pending_operations(pending_operations)
+    metadata_all.generate_metadata_all_draft()
 
 
 def remove(dataset_name: str):
@@ -47,6 +49,7 @@ def remove(dataset_name: str):
     pending_operations["releaseTime"] = date.seconds_since_epoch()
     __archive()
     datastore.write_pending_operations(pending_operations)
+    metadata_all.generate_metadata_all_draft()
 
 
 def set_release_status(dataset_name: str, release_status: str, operation: str,
@@ -78,6 +81,7 @@ def set_release_status(dataset_name: str, release_status: str, operation: str,
             pending_operations["dataStructureUpdates"]
         )
         datastore.write_pending_operations(pending_operations)
+        metadata_all.generate_metadata_all_draft()
     else:
         if datastore.is_dataset_in_data_store(dataset_name, 'RELEASED'):
             __check_if_transition_allowed('RELEASED', release_status)
@@ -103,6 +107,11 @@ def get_release_status(dataset_name: str) -> str:
         )
     except StopIteration:
         return None
+
+
+def get_datastructure_updates() -> list:
+    pending_operations = datastore.get_pending_operations()
+    return pending_operations["dataStructureUpdates"]
 
 
 def __check_if_transition_allowed(old_release_status, new_release_status):

--- a/tests/resources/SSB_FDB/datastore/pending_operations.json
+++ b/tests/resources/SSB_FDB/datastore/pending_operations.json
@@ -11,11 +11,17 @@
             "releaseStatus": "DRAFT"
         },
         {
-            "name" : "ANOTHER_TEST_DATASET",
-            "operation" : "ADD",
-            "description" : "Enda et datasett om test",
+            "name": "ANOTHER_TEST_DATASET",
+            "operation": "ADD",
+            "description": "Enda et datasett om test",
             "releaseStatus": "DRAFT"
+        },
+        {
+            "name": "SKATT_BRUTTOINNTEKT",
+            "operation": "REMOVE",
+            "description": "Fjernet dataset",
+            "releaseStatus": "PENDING_DELETE"
         }
     ],
-    "updateType": ""
+    "updateType": "MAJOR"
 }

--- a/tests/resources/SSB_FDB/metadata/ANOTHER_TEST_DATASET/ANOTHER_TEST_DATASET__0_0_0.json
+++ b/tests/resources/SSB_FDB/metadata/ANOTHER_TEST_DATASET/ANOTHER_TEST_DATASET__0_0_0.json
@@ -1,0 +1,136 @@
+{
+    "name": "ANOTHER_TEST_DATASET",
+    "temporalCoverage": {
+      "start": -15492,
+      "stop": 18583
+    },
+    "temporality": "STATUS",
+    "identifierVariables": [
+      {
+        "variableRole": "Identifier",
+        "name": "PERSONID_1",
+        "label": "Personidentifikator",
+        "dataType": "STRING",
+        "representedVariables": [
+          {
+            "validPeriod": {
+              "start": -15492,
+              "stop": 18583
+            },
+            "description": "Identifikator for person i form av fødselsnummer eller d-nummer.",
+            "valueDomain": {
+              "description": "Pseudonymisert fødselsnummer"
+            }
+          }
+        ]
+      }
+    ],
+    "measureVariable": {
+      "name": "ANOTHER_TEST_DATASET",
+      "label": "Sivilstand",
+      "dataType": "STRING",
+      "representedVariables": [
+        {
+          "description": "Kopiert fra sivilstand.",
+          "validPeriod": {
+            "start": -2192,
+            "stop": 8400
+          },
+          "valueDomain": {
+            "codeList": [
+              {
+                "category": "Ugift",
+                "code": "1"
+              },
+              {
+                "category": "Gift",
+                "code": "2"
+              },
+              {
+                "category": "Enke/enkemann",
+                "code": "3"
+              },
+              {
+                "category": "Skilt",
+                "code": "4"
+              },
+              {
+                "category": "Separert",
+                "code": "5"
+              }
+            ]
+          }
+        },
+        {
+          "description": "Kopiert fra sivilstand.",
+          "validPeriod": {
+            "start": 8401
+          },
+          "valueDomain": {
+            "codeList": [
+              {
+                "category": "Ugift",
+                "code": "1"
+              },
+              {
+                "category": "Gift",
+                "code": "2"
+              },
+              {
+                "category": "Enke/enkemann",
+                "code": "3"
+              },
+              {
+                "category": "Skilt",
+                "code": "4"
+              },
+              {
+                "category": "Separert",
+                "code": "5"
+              },
+              {
+                "category": "Registrert partner",
+                "code": "6"
+              },
+              {
+                "category": "Separert partner",
+                "code": "7"
+              },
+              {
+                "category": "Skilt partner",
+                "code": "8"
+              },
+              {
+                "category": "Gjenlevende partner",
+                "code": "9"
+              }
+            ]
+          }
+        }
+      ],
+      "keyType": {
+        "name": "PERSON",
+        "label": "Person",
+        "description": "Person."
+      }
+    },
+    "subjectFields": [
+      "Befolkning",
+      "Folketall"
+    ],
+    "languageCode": "no",
+    "attributeVariables": [
+      {
+        "name": "START",
+        "label": "Startdato",
+        "dataType": "Instant",
+        "variableRole": "START_TIME"
+      },
+      {
+        "name": "STOP",
+        "label": "Stoppdato",
+        "dataType": "Instant",
+        "variableRole": "STOP_TIME"
+      }
+    ]
+  }

--- a/tests/resources/SSB_FDB/metadata/ANOTHER_TEST_DATASET/ANOTHER_TEST_DATASET__0_0_0.json
+++ b/tests/resources/SSB_FDB/metadata/ANOTHER_TEST_DATASET/ANOTHER_TEST_DATASET__0_0_0.json
@@ -1,136 +1,136 @@
 {
     "name": "ANOTHER_TEST_DATASET",
     "temporalCoverage": {
-      "start": -15492,
-      "stop": 18583
+        "start": -15492,
+        "stop": 18583
     },
     "temporality": "STATUS",
     "identifierVariables": [
-      {
-        "variableRole": "Identifier",
-        "name": "PERSONID_1",
-        "label": "Personidentifikator",
-        "dataType": "STRING",
-        "representedVariables": [
-          {
-            "validPeriod": {
-              "start": -15492,
-              "stop": 18583
-            },
-            "description": "Identifikator for person i form av fødselsnummer eller d-nummer.",
-            "valueDomain": {
-              "description": "Pseudonymisert fødselsnummer"
-            }
-          }
-        ]
-      }
+        {
+            "variableRole": "Identifier",
+            "name": "PERSONID_1",
+            "label": "Personidentifikator",
+            "dataType": "STRING",
+            "representedVariables": [
+                {
+                    "validPeriod": {
+                        "start": -15492,
+                        "stop": 18583
+                    },
+                    "description": "Identifikator for person i form av fødselsnummer eller d-nummer.",
+                    "valueDomain": {
+                        "description": "Pseudonymisert fødselsnummer"
+                    }
+                }
+            ]
+        }
     ],
     "measureVariable": {
-      "name": "ANOTHER_TEST_DATASET",
-      "label": "Sivilstand",
-      "dataType": "STRING",
-      "representedVariables": [
-        {
-          "description": "Kopiert fra sivilstand.",
-          "validPeriod": {
-            "start": -2192,
-            "stop": 8400
-          },
-          "valueDomain": {
-            "codeList": [
-              {
-                "category": "Ugift",
-                "code": "1"
-              },
-              {
-                "category": "Gift",
-                "code": "2"
-              },
-              {
-                "category": "Enke/enkemann",
-                "code": "3"
-              },
-              {
-                "category": "Skilt",
-                "code": "4"
-              },
-              {
-                "category": "Separert",
-                "code": "5"
-              }
-            ]
-          }
-        },
-        {
-          "description": "Kopiert fra sivilstand.",
-          "validPeriod": {
-            "start": 8401
-          },
-          "valueDomain": {
-            "codeList": [
-              {
-                "category": "Ugift",
-                "code": "1"
-              },
-              {
-                "category": "Gift",
-                "code": "2"
-              },
-              {
-                "category": "Enke/enkemann",
-                "code": "3"
-              },
-              {
-                "category": "Skilt",
-                "code": "4"
-              },
-              {
-                "category": "Separert",
-                "code": "5"
-              },
-              {
-                "category": "Registrert partner",
-                "code": "6"
-              },
-              {
-                "category": "Separert partner",
-                "code": "7"
-              },
-              {
-                "category": "Skilt partner",
-                "code": "8"
-              },
-              {
-                "category": "Gjenlevende partner",
-                "code": "9"
-              }
-            ]
-          }
+        "name": "ANOTHER_TEST_DATASET",
+        "label": "Sivilstand",
+        "dataType": "STRING",
+        "representedVariables": [
+            {
+                "description": "Kopiert fra sivilstand.",
+                "validPeriod": {
+                    "start": -2192,
+                    "stop": 8400
+                },
+                "valueDomain": {
+                    "codeList": [
+                        {
+                            "category": "Ugift",
+                            "code": "1"
+                        },
+                        {
+                            "category": "Gift",
+                            "code": "2"
+                        },
+                        {
+                            "category": "Enke/enkemann",
+                            "code": "3"
+                        },
+                        {
+                            "category": "Skilt",
+                            "code": "4"
+                        },
+                        {
+                            "category": "Separert",
+                            "code": "5"
+                        }
+                    ]
+                }
+            },
+            {
+                "description": "Kopiert fra sivilstand.",
+                "validPeriod": {
+                    "start": 8401
+                },
+                "valueDomain": {
+                    "codeList": [
+                        {
+                            "category": "Ugift",
+                            "code": "1"
+                        },
+                        {
+                            "category": "Gift",
+                            "code": "2"
+                        },
+                        {
+                            "category": "Enke/enkemann",
+                            "code": "3"
+                        },
+                        {
+                            "category": "Skilt",
+                            "code": "4"
+                        },
+                        {
+                            "category": "Separert",
+                            "code": "5"
+                        },
+                        {
+                            "category": "Registrert partner",
+                            "code": "6"
+                        },
+                        {
+                            "category": "Separert partner",
+                            "code": "7"
+                        },
+                        {
+                            "category": "Skilt partner",
+                            "code": "8"
+                        },
+                        {
+                            "category": "Gjenlevende partner",
+                            "code": "9"
+                        }
+                    ]
+                }
+            }
+        ],
+        "keyType": {
+            "name": "PERSON",
+            "label": "Person",
+            "description": "Person."
         }
-      ],
-      "keyType": {
-        "name": "PERSON",
-        "label": "Person",
-        "description": "Person."
-      }
     },
     "subjectFields": [
-      "Befolkning",
-      "Folketall"
+        "Befolkning",
+        "Folketall"
     ],
     "languageCode": "no",
     "attributeVariables": [
-      {
-        "name": "START",
-        "label": "Startdato",
-        "dataType": "Instant",
-        "variableRole": "START_TIME"
-      },
-      {
-        "name": "STOP",
-        "label": "Stoppdato",
-        "dataType": "Instant",
-        "variableRole": "STOP_TIME"
-      }
+        {
+            "name": "START",
+            "label": "Startdato",
+            "dataType": "Instant",
+            "variableRole": "START_TIME"
+        },
+        {
+            "name": "STOP",
+            "label": "Stoppdato",
+            "dataType": "Instant",
+            "variableRole": "STOP_TIME"
+        }
     ]
-  }
+}

--- a/tests/resources/built_datasets/NEW_VARIABLE/NEW_VARIABLE__0_0_0.json
+++ b/tests/resources/built_datasets/NEW_VARIABLE/NEW_VARIABLE__0_0_0.json
@@ -3,98 +3,98 @@
     "populationDescription": "Omfatter alle skattepliktige i løpet av inntektsåret. Inkl. personer med dnr.",
     "temporality": "ACCUMULATED",
     "temporalCoverage": {
-      "start": 8401,
-      "stop": 18261
+        "start": 8401,
+        "stop": 18261
     },
     "identifierVariables": [
-      {
-        "name": "PERSONID_1",
-        "label": "Personidentifikator",
-        "representedVariables": [
-          {
-            "description": "Identifikator for person i RAIRD",
-            "validPeriod": {
-              "start": 8401,
-              "stop": 18261
+        {
+            "name": "PERSONID_1",
+            "label": "Personidentifikator",
+            "representedVariables": [
+                {
+                    "description": "Identifikator for person i RAIRD",
+                    "validPeriod": {
+                        "start": 8401,
+                        "stop": 18261
+                    },
+                    "valueDomain": {
+                        "description": "N/A",
+                        "unitOfMeasure": "N/A"
+                    }
+                }
+            ],
+            "dataType": "Long",
+            "variableRole": "Identifier",
+            "keyType": {
+                "name": "PERSON",
+                "label": "Person",
+                "description": "Statistisk enhet er person (individ, enkeltmenenske)"
             },
-            "valueDomain": {
-              "description": "N/A",
-              "unitOfMeasure": "N/A"
-            }
-          }
-        ],
-        "dataType": "Long",
-        "variableRole": "Identifier",
-        "keyType": {
-          "name": "PERSON",
-          "label": "Person",
-          "description": "Statistisk enhet er person (individ, enkeltmenenske)"
-        },
-        "format": "RandomUInt48"
-      }
+            "format": "RandomUInt48"
+        }
     ],
     "measureVariable": {
-      "name": "NEW_VARIABLE",
-      "label": "Bruttoinntekt",
-      "representedVariables": [
-        {
-          "description": "Variabelen omfatter lønnsinntekter, næringsinntekter, pensjoner og kapitalinntekter. \n \n https://www.ssb.no/a/metadata/conceptvariable/vardok/16/nb \n \n Variabelen omfatter alle skattepliktige i løpet av inntektsåret. Inkl. personer med dnr. Observasjoner med verdiene 0 og uoppgitt (missing) er utelatt.",
-          "validPeriod": {
-            "start": 8401,
-            "stop": 18261
-          },
-          "valueDomain": {
-            "description": "NOK",
-            "unitOfMeasure": "NOK"
-          }
-        }
-      ],
-      "dataType": "Long",
-      "variableRole": "Measure"
+        "name": "NEW_VARIABLE",
+        "label": "Bruttoinntekt",
+        "representedVariables": [
+            {
+                "description": "Variabelen omfatter lønnsinntekter, næringsinntekter, pensjoner og kapitalinntekter. \n \n https://www.ssb.no/a/metadata/conceptvariable/vardok/16/nb \n \n Variabelen omfatter alle skattepliktige i løpet av inntektsåret. Inkl. personer med dnr. Observasjoner med verdiene 0 og uoppgitt (missing) er utelatt.",
+                "validPeriod": {
+                    "start": 8401,
+                    "stop": 18261
+                },
+                "valueDomain": {
+                    "description": "NOK",
+                    "unitOfMeasure": "NOK"
+                }
+            }
+        ],
+        "dataType": "Long",
+        "variableRole": "Measure"
     },
     "subjectFields": [
-      "Skatt for personer",
-      "Inntekt og forbruk"
+        "Skatt for personer",
+        "Inntekt og forbruk"
     ],
     "languageCode": "no",
     "attributeVariables": [
-      {
-        "name": "START",
-        "label": "Startdato",
-        "representedVariables": [
-          {
-            "description": "Startdato/måletidspunktet for hendelsen",
-            "validPeriod": {
-              "start": 8401,
-              "stop": 18261
-            },
-            "valueDomain": {
-              "description": "N/A",
-              "unitOfMeasure": "N/A"
-            }
-          }
-        ],
-        "dataType": "Instant",
-        "variableRole": "Start"
-      },
-      {
-        "name": "STOP",
-        "label": "Stoppdato",
-        "representedVariables": [
-          {
-            "description": "Stoppdato/sluttdato for hendelsen",
-            "validPeriod": {
-              "start": 8401,
-              "stop": 18261
-            },
-            "valueDomain": {
-              "description": "N/A",
-              "unitOfMeasure": "N/A"
-            }
-          }
-        ],
-        "dataType": "Instant",
-        "variableRole": "Stop"
-      }
+        {
+            "name": "START",
+            "label": "Startdato",
+            "representedVariables": [
+                {
+                    "description": "Startdato/måletidspunktet for hendelsen",
+                    "validPeriod": {
+                        "start": 8401,
+                        "stop": 18261
+                    },
+                    "valueDomain": {
+                        "description": "N/A",
+                        "unitOfMeasure": "N/A"
+                    }
+                }
+            ],
+            "dataType": "Instant",
+            "variableRole": "Start"
+        },
+        {
+            "name": "STOP",
+            "label": "Stoppdato",
+            "representedVariables": [
+                {
+                    "description": "Stoppdato/sluttdato for hendelsen",
+                    "validPeriod": {
+                        "start": 8401,
+                        "stop": 18261
+                    },
+                    "valueDomain": {
+                        "description": "N/A",
+                        "unitOfMeasure": "N/A"
+                    }
+                }
+            ],
+            "dataType": "Instant",
+            "variableRole": "Stop"
+        }
     ]
-  }
+}

--- a/tests/resources/built_datasets/NEW_VARIABLE/NEW_VARIABLE__0_0_0.json
+++ b/tests/resources/built_datasets/NEW_VARIABLE/NEW_VARIABLE__0_0_0.json
@@ -1,0 +1,100 @@
+{
+    "name": "NEW_VARIABLE",
+    "populationDescription": "Omfatter alle skattepliktige i løpet av inntektsåret. Inkl. personer med dnr.",
+    "temporality": "ACCUMULATED",
+    "temporalCoverage": {
+      "start": 8401,
+      "stop": 18261
+    },
+    "identifierVariables": [
+      {
+        "name": "PERSONID_1",
+        "label": "Personidentifikator",
+        "representedVariables": [
+          {
+            "description": "Identifikator for person i RAIRD",
+            "validPeriod": {
+              "start": 8401,
+              "stop": 18261
+            },
+            "valueDomain": {
+              "description": "N/A",
+              "unitOfMeasure": "N/A"
+            }
+          }
+        ],
+        "dataType": "Long",
+        "variableRole": "Identifier",
+        "keyType": {
+          "name": "PERSON",
+          "label": "Person",
+          "description": "Statistisk enhet er person (individ, enkeltmenenske)"
+        },
+        "format": "RandomUInt48"
+      }
+    ],
+    "measureVariable": {
+      "name": "NEW_VARIABLE",
+      "label": "Bruttoinntekt",
+      "representedVariables": [
+        {
+          "description": "Variabelen omfatter lønnsinntekter, næringsinntekter, pensjoner og kapitalinntekter. \n \n https://www.ssb.no/a/metadata/conceptvariable/vardok/16/nb \n \n Variabelen omfatter alle skattepliktige i løpet av inntektsåret. Inkl. personer med dnr. Observasjoner med verdiene 0 og uoppgitt (missing) er utelatt.",
+          "validPeriod": {
+            "start": 8401,
+            "stop": 18261
+          },
+          "valueDomain": {
+            "description": "NOK",
+            "unitOfMeasure": "NOK"
+          }
+        }
+      ],
+      "dataType": "Long",
+      "variableRole": "Measure"
+    },
+    "subjectFields": [
+      "Skatt for personer",
+      "Inntekt og forbruk"
+    ],
+    "languageCode": "no",
+    "attributeVariables": [
+      {
+        "name": "START",
+        "label": "Startdato",
+        "representedVariables": [
+          {
+            "description": "Startdato/måletidspunktet for hendelsen",
+            "validPeriod": {
+              "start": 8401,
+              "stop": 18261
+            },
+            "valueDomain": {
+              "description": "N/A",
+              "unitOfMeasure": "N/A"
+            }
+          }
+        ],
+        "dataType": "Instant",
+        "variableRole": "Start"
+      },
+      {
+        "name": "STOP",
+        "label": "Stoppdato",
+        "representedVariables": [
+          {
+            "description": "Stoppdato/sluttdato for hendelsen",
+            "validPeriod": {
+              "start": 8401,
+              "stop": 18261
+            },
+            "valueDomain": {
+              "description": "N/A",
+              "unitOfMeasure": "N/A"
+            }
+          }
+        ],
+        "dataType": "Instant",
+        "variableRole": "Stop"
+      }
+    ]
+  }

--- a/tests/resources/built_datasets/SKATT_BRUTTOINNTEKT/SKATT_BRUTTOINNTEKT__0_0_0.json
+++ b/tests/resources/built_datasets/SKATT_BRUTTOINNTEKT/SKATT_BRUTTOINNTEKT__0_0_0.json
@@ -1,0 +1,100 @@
+{
+    "name": "SKATT_BRUTTOINNTEKT",
+    "populationDescription": "Omfatter alle skattepliktige i løpet av inntektsåret. Inkl. personer med dnr.",
+    "temporality": "ACCUMULATED",
+    "temporalCoverage": {
+      "start": 8401,
+      "stop": 18261
+    },
+    "identifierVariables": [
+      {
+        "name": "PERSONID_1",
+        "label": "Personidentifikator",
+        "representedVariables": [
+          {
+            "description": "Identifikator for person i RAIRD",
+            "validPeriod": {
+              "start": 8401,
+              "stop": 18261
+            },
+            "valueDomain": {
+              "description": "N/A",
+              "unitOfMeasure": "N/A"
+            }
+          }
+        ],
+        "dataType": "Long",
+        "variableRole": "Identifier",
+        "keyType": {
+          "name": "PERSON",
+          "label": "Person",
+          "description": "Statistisk enhet er person (individ, enkeltmenenske)"
+        },
+        "format": "RandomUInt48"
+      }
+    ],
+    "measureVariable": {
+      "name": "SKATT_BRUTTOINNTEKT",
+      "label": "Bruttoinntekt",
+      "representedVariables": [
+        {
+          "description": "Variabelen omfatter lønnsinntekter, næringsinntekter, pensjoner og kapitalinntekter. \n \n https://www.ssb.no/a/metadata/conceptvariable/vardok/16/nb \n \n Variabelen omfatter alle skattepliktige i løpet av inntektsåret. Inkl. personer med dnr. Observasjoner med verdiene 0 og uoppgitt (missing) er utelatt.",
+          "validPeriod": {
+            "start": 8401,
+            "stop": 18261
+          },
+          "valueDomain": {
+            "description": "NOK",
+            "unitOfMeasure": "NOK"
+          }
+        }
+      ],
+      "dataType": "Long",
+      "variableRole": "Measure"
+    },
+    "subjectFields": [
+      "Skatt for personer",
+      "Inntekt og forbruk"
+    ],
+    "languageCode": "no",
+    "attributeVariables": [
+      {
+        "name": "START",
+        "label": "Startdato",
+        "representedVariables": [
+          {
+            "description": "Startdato/måletidspunktet for hendelsen",
+            "validPeriod": {
+              "start": 8401,
+              "stop": 18261
+            },
+            "valueDomain": {
+              "description": "N/A",
+              "unitOfMeasure": "N/A"
+            }
+          }
+        ],
+        "dataType": "Instant",
+        "variableRole": "Start"
+      },
+      {
+        "name": "STOP",
+        "label": "Stoppdato",
+        "representedVariables": [
+          {
+            "description": "Stoppdato/sluttdato for hendelsen",
+            "validPeriod": {
+              "start": 8401,
+              "stop": 18261
+            },
+            "valueDomain": {
+              "description": "N/A",
+              "unitOfMeasure": "N/A"
+            }
+          }
+        ],
+        "dataType": "Instant",
+        "variableRole": "Stop"
+      }
+    ]
+  }

--- a/tests/resources/built_datasets/SKATT_BRUTTOINNTEKT/SKATT_BRUTTOINNTEKT__0_0_0.json
+++ b/tests/resources/built_datasets/SKATT_BRUTTOINNTEKT/SKATT_BRUTTOINNTEKT__0_0_0.json
@@ -3,98 +3,98 @@
     "populationDescription": "Omfatter alle skattepliktige i løpet av inntektsåret. Inkl. personer med dnr.",
     "temporality": "ACCUMULATED",
     "temporalCoverage": {
-      "start": 8401,
-      "stop": 18261
+        "start": 8401,
+        "stop": 18261
     },
     "identifierVariables": [
-      {
-        "name": "PERSONID_1",
-        "label": "Personidentifikator",
-        "representedVariables": [
-          {
-            "description": "Identifikator for person i RAIRD",
-            "validPeriod": {
-              "start": 8401,
-              "stop": 18261
+        {
+            "name": "PERSONID_1",
+            "label": "Personidentifikator",
+            "representedVariables": [
+                {
+                    "description": "Identifikator for person i RAIRD",
+                    "validPeriod": {
+                        "start": 8401,
+                        "stop": 18261
+                    },
+                    "valueDomain": {
+                        "description": "N/A",
+                        "unitOfMeasure": "N/A"
+                    }
+                }
+            ],
+            "dataType": "Long",
+            "variableRole": "Identifier",
+            "keyType": {
+                "name": "PERSON",
+                "label": "Person",
+                "description": "Statistisk enhet er person (individ, enkeltmenenske)"
             },
-            "valueDomain": {
-              "description": "N/A",
-              "unitOfMeasure": "N/A"
-            }
-          }
-        ],
-        "dataType": "Long",
-        "variableRole": "Identifier",
-        "keyType": {
-          "name": "PERSON",
-          "label": "Person",
-          "description": "Statistisk enhet er person (individ, enkeltmenenske)"
-        },
-        "format": "RandomUInt48"
-      }
+            "format": "RandomUInt48"
+        }
     ],
     "measureVariable": {
-      "name": "SKATT_BRUTTOINNTEKT",
-      "label": "Bruttoinntekt",
-      "representedVariables": [
-        {
-          "description": "Variabelen omfatter lønnsinntekter, næringsinntekter, pensjoner og kapitalinntekter. \n \n https://www.ssb.no/a/metadata/conceptvariable/vardok/16/nb \n \n Variabelen omfatter alle skattepliktige i løpet av inntektsåret. Inkl. personer med dnr. Observasjoner med verdiene 0 og uoppgitt (missing) er utelatt.",
-          "validPeriod": {
-            "start": 8401,
-            "stop": 18261
-          },
-          "valueDomain": {
-            "description": "NOK",
-            "unitOfMeasure": "NOK"
-          }
-        }
-      ],
-      "dataType": "Long",
-      "variableRole": "Measure"
+        "name": "SKATT_BRUTTOINNTEKT",
+        "label": "Bruttoinntekt",
+        "representedVariables": [
+            {
+                "description": "Variabelen omfatter lønnsinntekter, næringsinntekter, pensjoner og kapitalinntekter. \n \n https://www.ssb.no/a/metadata/conceptvariable/vardok/16/nb \n \n Variabelen omfatter alle skattepliktige i løpet av inntektsåret. Inkl. personer med dnr. Observasjoner med verdiene 0 og uoppgitt (missing) er utelatt.",
+                "validPeriod": {
+                    "start": 8401,
+                    "stop": 18261
+                },
+                "valueDomain": {
+                    "description": "NOK",
+                    "unitOfMeasure": "NOK"
+                }
+            }
+        ],
+        "dataType": "Long",
+        "variableRole": "Measure"
     },
     "subjectFields": [
-      "Skatt for personer",
-      "Inntekt og forbruk"
+        "Skatt for personer",
+        "Inntekt og forbruk"
     ],
     "languageCode": "no",
     "attributeVariables": [
-      {
-        "name": "START",
-        "label": "Startdato",
-        "representedVariables": [
-          {
-            "description": "Startdato/måletidspunktet for hendelsen",
-            "validPeriod": {
-              "start": 8401,
-              "stop": 18261
-            },
-            "valueDomain": {
-              "description": "N/A",
-              "unitOfMeasure": "N/A"
-            }
-          }
-        ],
-        "dataType": "Instant",
-        "variableRole": "Start"
-      },
-      {
-        "name": "STOP",
-        "label": "Stoppdato",
-        "representedVariables": [
-          {
-            "description": "Stoppdato/sluttdato for hendelsen",
-            "validPeriod": {
-              "start": 8401,
-              "stop": 18261
-            },
-            "valueDomain": {
-              "description": "N/A",
-              "unitOfMeasure": "N/A"
-            }
-          }
-        ],
-        "dataType": "Instant",
-        "variableRole": "Stop"
-      }
+        {
+            "name": "START",
+            "label": "Startdato",
+            "representedVariables": [
+                {
+                    "description": "Startdato/måletidspunktet for hendelsen",
+                    "validPeriod": {
+                        "start": 8401,
+                        "stop": 18261
+                    },
+                    "valueDomain": {
+                        "description": "N/A",
+                        "unitOfMeasure": "N/A"
+                    }
+                }
+            ],
+            "dataType": "Instant",
+            "variableRole": "Start"
+        },
+        {
+            "name": "STOP",
+            "label": "Stoppdato",
+            "representedVariables": [
+                {
+                    "description": "Stoppdato/sluttdato for hendelsen",
+                    "validPeriod": {
+                        "start": 8401,
+                        "stop": 18261
+                    },
+                    "valueDomain": {
+                        "description": "N/A",
+                        "unitOfMeasure": "N/A"
+                    }
+                }
+            ],
+            "dataType": "Instant",
+            "variableRole": "Stop"
+        }
     ]
-  }
+}

--- a/tests/unit/domain/test_metadata_all.py
+++ b/tests/unit/domain/test_metadata_all.py
@@ -1,0 +1,43 @@
+import pytest
+import shutil
+from datastore_version_manager.domain import metadata_all
+from datastore_version_manager.adapter import datastore
+
+
+DATASTORE_ROOT_DIR = 'tests/resources/SSB_FDB'
+ARCHIVE_DIR = f'{DATASTORE_ROOT_DIR}/archive/pending_operations'
+
+
+def setup_function():
+    shutil.copytree(
+        'tests/resources',
+        'tests/resources_backup'
+    )
+
+
+def teardown_function():
+    shutil.rmtree('tests/resources')
+    shutil.move(
+        'tests/resources_backup',
+        'tests/resources'
+    )
+
+
+@pytest.fixture(autouse=True)
+def setup_environment(monkeypatch):
+    monkeypatch.setenv('DATASTORE_ROOT_DIR', DATASTORE_ROOT_DIR)
+    monkeypatch.setenv(
+        'DATASET_BUILDER_OUTPUT_DIR', 'tests/resources/built_datasets'
+    )
+
+
+def test_generate_metadata_all_draft():
+    metadata_all.generate_metadata_all_draft()
+    metadata_all_draft = datastore.get_metadata_all('draft')
+    data_structures = [
+        data_structure['name']
+        for data_structure in metadata_all_draft['dataStructures']
+    ]
+    assert data_structures == [
+        'PERSON_SIVILSTAND', 'TEST_DATASET', 'ANOTHER_TEST_DATASET'
+    ]

--- a/tests/unit/domain/test_metadata_all.py
+++ b/tests/unit/domain/test_metadata_all.py
@@ -5,7 +5,6 @@ from datastore_version_manager.adapter import datastore
 
 
 DATASTORE_ROOT_DIR = 'tests/resources/SSB_FDB'
-ARCHIVE_DIR = f'{DATASTORE_ROOT_DIR}/archive/pending_operations'
 
 
 def setup_function():

--- a/tests/unit/domain/test_pending_operations.py
+++ b/tests/unit/domain/test_pending_operations.py
@@ -37,12 +37,16 @@ def test_remove_dataset_from_pending_operations():
     pending_operations.remove(dataset_name)
 
     actual_pending_operations = datastore.get_pending_operations()
+    draft_metadata_all = datastore.get_metadata_all('draft')
 
-    assert actual_pending_operations["updateType"] == ''
+    assert actual_pending_operations["updateType"] == 'MAJOR'
     assert os.path.exists(f'{ARCHIVE_DIR}/pending_operation__0_0_0_1.json')
-    assert len(actual_pending_operations["dataStructureUpdates"]) == 1
-    if datastore.draft_dataset_exists(dataset_name):
-        assert False
+    assert len(actual_pending_operations["dataStructureUpdates"]) == 2
+    assert not datastore.draft_dataset_exists(dataset_name)
+    assert not any([
+        data_structure["name"] == dataset_name
+        for data_structure in draft_metadata_all["dataStructures"]
+    ])
 
 
 def test_remove_non_existing_dataset_from_pending_operations():


### PR DESCRIPTION
# GENERATE METADATA ALL DRAFT

generate new metadata_all_draft.json when changing pending_operations.json.

## How?
1. Updating pending operations in a way that would morph metadata_all_draft (pending_delete, add, remove_draft)
2. Start by copying the latest released metadata_all
3. Go through data structures in pending operations
    * if PENDING_DELETE: remove dataset from metadata_all
    * else if ADD: add draft metadata to metadata_all
    * else id CHANGE_DATA: delete old metadata for dataset and add draft metadata to metadata_all
    * write new metadata_all_draft to datastore
