### PR TITLE
Api method returns a dict instead of list

### DIFF
--- a/datastore_version_manager/api/command_api.py
+++ b/datastore_version_manager/api/command_api.py
@@ -90,4 +90,4 @@ def apply_bump_manifesto(body: ApplyBumpManifestoRequest):
 @validate()
 def get_released_datasets():
     logger.info(f'GET /released-datasets')
-    return datastore_versions.get_released_datasets()
+    return {"released_datasets": datastore_versions.get_released_datasets()}

--- a/datastore_version_manager/api/command_api.py
+++ b/datastore_version_manager/api/command_api.py
@@ -90,4 +90,4 @@ def apply_bump_manifesto(body: ApplyBumpManifestoRequest):
 @validate()
 def get_released_datasets():
     logger.info(f'GET /released-datasets')
-    return {"released_datasets": datastore_versions.get_released_datasets()}
+    return jsonify(datastore_versions.get_released_datasets())


### PR DESCRIPTION
The api returned a list but got:

"TypeError: The view function did not return a valid response. The return type must be a string, dict, tuple, Response instance, or WSGI callable, but it was a list."